### PR TITLE
parse gre link attribute

### DIFF
--- a/link_linux.go
+++ b/link_linux.go
@@ -2344,6 +2344,8 @@ func parseGretunData(link Link, data []syscall.NetlinkRouteAttr) {
 	gre := link.(*Gretun)
 	for _, datum := range data {
 		switch datum.Attr.Type {
+		case nl.IFLA_GRE_LINK:
+			gre.Link = native.Uint32(datum.Value[0:4])
 		case nl.IFLA_GRE_IKEY:
 			gre.IKey = ntohl(datum.Value[0:4])
 		case nl.IFLA_GRE_OKEY:


### PR DESCRIPTION
Update `parseGretunData` to parse Link attribute. Link attrbute is the indicator of the device to be used for tunnel endpoint communications.